### PR TITLE
chore: prevent indexing of site content

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
       lastUpdated: true,
       editLink: {
         baseUrl: "https://github.com/newjersey/innovation-engineering/edit/main/",
+        head: [{ tag: "meta", attrs: { name: "robots", content: "noindex, nofollow" } }],
       },
       social: [
         {


### PR DESCRIPTION
This change prevents the site being indexed by Googlebot and other robots. This is a workaround given we can't deploy a robots.txt at the root folder of the subdomain, so this is the next best option.