### PR TITLE
Update design system doc, add Grove references

### DIFF
--- a/src/content/docs/tech-recommendations/design-system.md
+++ b/src/content/docs/tech-recommendations/design-system.md
@@ -1,9 +1,19 @@
 ---
-title: Design system
-wip: true
+title: Design system (Grove)
 ---
 
-We use NJWDS for micro-css classes, not Tailwind or similar
+## Grove design system
 
-For React apps, also add the <https://github.com/trussworks/react-uswds> component library
-For non-react, include the USWDS javascript
+[Grove](https://grove.nj.gov/) is the Garden State Design System that we expect projects to use. This was formerly called NJWDS; you may see references to this old name in some code or documentation.
+
+Quick links:
+
+- [Grove documentation](https://grove.nj.gov/guides/gettingstarted/)
+- [Storybook components](https://storybook.grove.nj.gov/)
+- [GitHub repo](https://github.com/newjersey/njwds)
+
+For questions or information on the design system, talk to the team in Slack in the `#grove-all` channel.
+
+## Usage
+
+Use the [Trussworks implementation](https://github.com/trussworks/react-uswds) of USWDS components when building React components that follow the design system specs. Here is an [example of project code](https://github.com/newjersey/doula-medicaid/tree/main/src/app/form/(formSteps)/components) that wraps the Trussworks form components.


### PR DESCRIPTION
Context:
- Need to ensure all links for design system go to grove.nj.gov - [slack context](https://njcio.slack.com/archives/C05CV8H2QJU/p1783444650383989)
- Publicize that we use trussworks for wrapping design system form components - [slack context 1](https://njcio.slack.com/archives/C03C7NHK9B4/p1783370669422619) and [slack context 2](https://njcio.slack.com/archives/C03C7NHK9B4/p1782244623299039)