### PR TITLE
Update AI coding assistant model docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project will be documented in this file. See [commit
 
 ## [0.1.38](https://github.com/newjersey/innovation-engineering/compare/v0.1.37...v0.1.38) (2026-06-29)
 
-
 ### Features
 
 * prefer uv over pyenv ([37ba6d9](https://github.com/newjersey/innovation-engineering/commit/37ba6d96c96a7fbb59672ec78fb6473659b95683))

--- a/src/content/docs/guides/development/claude-code-bedrock.md
+++ b/src/content/docs/guides/development/claude-code-bedrock.md
@@ -328,7 +328,7 @@ available in Bedrock.
    ```json
    {
      "env": {
-       "ANTHROPIC_MODEL": "us.anthropic.claude-sonnet-4-6"
+       "ANTHROPIC_MODEL": "us.anthropic.claude-sonnet-5"
      }
    }
    ```
@@ -347,7 +347,7 @@ Web Fetch uses Haiku — so you can pin each role independently.
 {
   "env": {
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "us.anthropic.claude-opus-4-8",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "us.anthropic.claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "us.anthropic.claude-sonnet-5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
   }
 }
@@ -390,7 +390,7 @@ your AWS account has data retention disabled. For this reason:
     "AWS_REGION": "us-east-1",
     "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "us.anthropic.claude-opus-4-8",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "us.anthropic.claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "us.anthropic.claude-sonnet-5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
   },
   "model": "opusplan",
@@ -423,6 +423,7 @@ alongside `availableModels`:
 
 ```json
 "fallbackModel": [
+  "us.anthropic.claude-sonnet-5",
   "us.anthropic.claude-sonnet-4-6",
   "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
   "us.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -447,5 +448,5 @@ see [Set up AWS CLI with SSO: Troubleshooting](/innovation-engineering/guides/de
 | `aws sso login` succeeds but Claude Code still fails | The profile you logged in with doesn't match `AWS_PROFILE` in `~/.claude/settings.json`, or stale env vars are overriding it | Confirm `AWS_PROFILE` value matches your profile name exactly. Run `env \| grep AWS_` to check for overriding env vars; unset any you find. |
 | Region error on startup                              | `AWS_REGION` isn't set (or isn't being picked up)                                                                            | Set `AWS_REGION` in `~/.claude/settings.json` or your shell env; restart `claude`                                                           |
 | `AccessDeniedException` invoking a model             | Missing IAM permission and/or model access not granted in Bedrock console                                                    | Confirm IAM includes `bedrock:InvokeModel` (and streaming if needed); check Bedrock console model access/approvals for your account/region  |
-| Every message fails immediately                      | Incorrect `ANTHROPIC_MODEL` value or mismatched region/model                                                                 | Remove `ANTHROPIC_MODEL` to test; then re-add using a cross-region inference profile ID (e.g. `us.anthropic.claude-sonnet-4-6`)             |
+| Every message fails immediately                      | Incorrect `ANTHROPIC_MODEL` value or mismatched region/model                                                                 | Remove `ANTHROPIC_MODEL` to test; then re-add using a cross-region inference profile ID (e.g. `us.anthropic.claude-sonnet-5`)               |
 | `/login` / `/logout` doesn't behave as expected      | Bedrock uses AWS auth, not an Anthropic API key login flow                                                                   | Use AWS auth (`aws sso login`, profiles, IAM creds) instead                                                                                 |

--- a/src/content/docs/guides/development/codex.md
+++ b/src/content/docs/guides/development/codex.md
@@ -48,12 +48,50 @@ If you are looking for the analogous Claude Code setup, see
 Create or edit `~/.codex/config.toml`:
 
 ```toml
-model = "openai.gpt-5.5"
+model = "openai.gpt-5.6-sol"
 model_provider = "amazon-bedrock"
 
 [model_providers.amazon-bedrock.aws]
 region = "us-east-2"
 ```
+
+:::note[Checking available Bedrock models]
+
+Use the AWS CLI to inspect the OpenAI models and inference profiles that are
+visible to your AWS profile in `us-east-2`:
+
+```shell
+AWS_PROFILE=<profile-name> aws bedrock list-foundation-models \
+  --region us-east-2 \
+  --by-provider OpenAI \
+  --query 'modelSummaries[].{modelId:modelId,modelName:modelName,status:modelLifecycle.status}' \
+  --output table
+```
+
+```shell
+AWS_PROFILE=<profile-name> aws bedrock list-inference-profiles \
+  --region us-east-2 \
+  --query 'inferenceProfileSummaries[?contains(inferenceProfileId, `openai`) || contains(inferenceProfileName, `OpenAI`) || contains(inferenceProfileName, `GPT`)].{id:inferenceProfileId,name:inferenceProfileName,status:status}' \
+  --output table
+```
+
+The Codex Bedrock path can expose OpenAI model IDs through Bedrock even when
+they do not appear in the standard Bedrock catalog output. If
+`openai.gpt-5.6-sol` is missing from the AWS command output, test the Codex
+runtime path directly:
+
+```shell
+AWS_PROFILE=<profile-name> codex exec --ephemeral \
+  -m openai.gpt-5.6-sol \
+  -c 'model_provider="amazon-bedrock"' \
+  "Reply with exactly: model-ok"
+```
+
+Expected result: Codex starts with `provider: amazon-bedrock`, uses
+`model: openai.gpt-5.6-sol`, and returns `model-ok`. This command makes a real
+model request, so it may incur minimal Bedrock usage.
+
+:::
 
 ## Step 2: Authenticate with AWS SSO
 
@@ -115,7 +153,7 @@ preferred `~/.codex/config.toml` reference for engineers using Bedrock:
 
 ```toml
 # For Amazon Bedrock:
-model = "openai.gpt-5.5"
+model = "openai.gpt-5.6-sol"
 model_provider = "amazon-bedrock"
 model_reasoning_effort = "high"
 personality = "pragmatic"
@@ -172,6 +210,8 @@ export AZURE_OPENAI_API_KEY=<your-azure-foundry-key>
 
 For the official Bedrock setup, see
 [Use Codex with Amazon Bedrock](https://developers.openai.com/codex/amazon-bedrock).
+For current OpenAI model guidance, see
+[Using GPT-5.6](https://developers.openai.com/api/docs/guides/latest-model).
 For more detail on Codex settings, see
 [Codex configuration basics](https://developers.openai.com/codex/config-basic).
 For more detail on sandbox and network behavior, see
@@ -191,5 +231,5 @@ see
 | Codex uses the wrong AWS account         | The profile passed to `AWS_PROFILE` is not the account you expected                                    | Run `aws sts get-caller-identity --profile <profile-name>` and restart Codex with the correct `AWS_PROFILE=<profile-name> codex`  |
 | `AWS_PROFILE` seems ignored              | Explicit access-key env vars (`AWS_ACCESS_KEY_ID`, etc.) are taking precedence                         | Run `env \| grep AWS_`, then unset stale values with `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN`            |
 | `AccessDeniedException` invoking a model | Missing IAM permission and/or model access not granted in Bedrock                                      | Confirm IAM includes Bedrock invoke permissions and check Bedrock model access for the AWS account and Region                     |
-| Region or model availability error       | The configured model is not available in the configured Region                                         | Confirm `openai.gpt-5.5` is available in `us-east-2`, or adjust `model` and `region` based on the Bedrock model availability list |
+| Region or model availability error       | The configured model is not available in the configured Region                                         | Confirm `openai.gpt-5.6-sol` works in `us-east-2`, or adjust `model` and `region` based on the Bedrock model availability list    |
 | `/status` does not show `amazon-bedrock` | Codex is not reading the expected `~/.codex/config.toml`, or `model_provider` is missing or misspelled | Confirm the config file is saved at `~/.codex/config.toml`, then restart Codex and check `/status` again                          |


### PR DESCRIPTION
## Summary
- update Codex Bedrock documentation to use `openai.gpt-5.6-sol`
- add a Starlight callout with AWS Bedrock model discovery commands and a Codex runtime probe
- update Claude Code Bedrock Sonnet pins to `us.anthropic.claude-sonnet-5`
