### PR TITLE
Plug RHF usage example, and Grove Pattern pages

### DIFF
--- a/src/content/docs/tech-recommendations/design-system.md
+++ b/src/content/docs/tech-recommendations/design-system.md
@@ -9,6 +9,7 @@ title: Design system (Grove)
 Quick links:
 
 - [Grove documentation](https://grove.nj.gov/guides/gettingstarted/)
+- Guidance on patterns like [conditional fields](https://grove.nj.gov/patterns/conditionalfields/) and [error validation](https://grove.nj.gov/patterns/errorvalidation/)
 - [Storybook components](https://storybook.grove.nj.gov/)
 - [GitHub repo](https://github.com/newjersey/njwds)
 

--- a/src/content/docs/tech-recommendations/frontend.md
+++ b/src/content/docs/tech-recommendations/frontend.md
@@ -35,6 +35,8 @@ For user input validation, either use:
 
 Additionally, [@hookform/lens](https://github.com/react-hook-form/lenses) may be useful for typesafe mapping of nested data to RHF.
 
+See [Design system (Grove) - Usage](/innovation-engineering/tech-recommendations/design-system/#usage) for examples of wrapping Grove components with RHF.
+
 Some existing projects may still handle form logic and validation in different ways.
 
 ## Testing


### PR DESCRIPTION
I wasn't really sure where it belonged, and a seems like the Grove Pattern pages in general could use more visibility, so I put it in both frontend and Grove.