### PR TITLE
Recommend default AWS cloudwatch encryption in most cases

### DIFF
--- a/src/content/docs/tech-recommendations/monitoring-analytics.md
+++ b/src/content/docs/tech-recommendations/monitoring-analytics.md
@@ -12,7 +12,7 @@ We use Google Analytics with Looker Studio
 ## Monitoring
 
 - Ensure you have some cloud-based logging in place that will allow you to debug failures. You must be informed _when_ something fails, be able to figure out _why_, and take actionable steps to _resolve_ for the user.
-  - By default, AWS Cloudwatch log groups are encrypted with a default AWS key and have an indefinite retention time. This is sufficient to meet the requirements of the [SISM (AU-07)](https://www.cyber.nj.gov/grants-and-resources/state-resources/statewide-information-security-manual-sism), that data be encrypted at rest and logs be retained for at least 1 year.
+  - By default, AWS Cloudwatch log groups are encrypted with a default AWS key and have an indefinite retention time. This is sufficient in most cases, and meets the requirements of the [SISM (AU-07)](https://www.cyber.nj.gov/grants-and-resources/state-resources/statewide-information-security-manual-sism), that data be encrypted at rest and logs be retained for at least 1 year.
     - If desired, Cloudwatch can be configured to instead [use KMS key for encryption](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html), which would allow us to rotate the key, and potentially destroy it and render the logs unreadable if needed
     - Cloudwatch can also be configured to retain logs for 1 year (instead of indefinitely), to reduce the surface of exposure should if the logs were to get exposed
 - Set up monitoring alerts - your dev team should be receiving some kind of notification (likely email or Slack) if your application has unexpected behavior


### PR DESCRIPTION
Per guidance from NJCCIC (emphasis added):

> The need for separate customer managed keys would depend on the sensitivity of the data within the logs and whether there are regulatory requirements requiring full control of the key management lifecycle for the encryption of that data. **In most cases, the Amazon managed keys are sufficient.** I also believe there is a cost associated with all of the API calls to the key management service, so this could be costly on a high volume log stream.